### PR TITLE
Remove deprecated functions after nnfabrik update.

### DIFF
--- a/nnvision/tables/from_nnfabrik.py
+++ b/nnvision/tables/from_nnfabrik.py
@@ -2,7 +2,7 @@ import datajoint as dj
 from nnfabrik.template import TrainedModelBase
 from nnfabrik.main import Model, Dataset, Trainer, Seed, Fabrikant
 from nnfabrik.utility.dj_helpers import gitlog, make_hash
-from nnfabrik.template import DataInfoBase, scoring_function_base
+from nnfabrik.template import DataInfoBase
 from nnfabrik.builder import resolve_data
 from nnfabrik.utility.dj_helpers import CustomSchema
 import os

--- a/nnvision/tables/main.py
+++ b/nnvision/tables/main.py
@@ -4,7 +4,6 @@ import datajoint as dj
 from ..utility.measures import get_oracles, get_explainable_var
 from nnfabrik.main import Dataset
 from nnfabrik.utility.dj_helpers import CustomSchema
-from nnfabrik.template import scoring_function_base
 from featurevis import integration
 
 schema = CustomSchema(dj.config.get('schema_name', 'nnfabrik_core'))


### PR DESCRIPTION
With the acceptance of the latest nnfabrik PR, an import of a deprecated function has to be deleted.